### PR TITLE
Mirror of facebook react#17651

### DIFF
--- a/packages/legacy-events/EventSystemFlags.js
+++ b/packages/legacy-events/EventSystemFlags.js
@@ -11,8 +11,9 @@ export type EventSystemFlags = number;
 
 export const PLUGIN_EVENT_SYSTEM = 1;
 export const RESPONDER_EVENT_SYSTEM = 1 << 1;
-export const IS_PASSIVE = 1 << 2;
-export const IS_ACTIVE = 1 << 3;
-export const PASSIVE_NOT_SUPPORTED = 1 << 4;
-export const IS_REPLAYED = 1 << 5;
-export const IS_FIRST_ANCESTOR = 1 << 6;
+export const LISTENER_EVENT_SYSTEM = 1 << 2;
+export const IS_PASSIVE = 1 << 3;
+export const IS_ACTIVE = 1 << 4;
+export const PASSIVE_NOT_SUPPORTED = 1 << 5;
+export const IS_REPLAYED = 1 << 6;
+export const IS_FIRST_ANCESTOR = 1 << 7;

--- a/packages/legacy-events/PluginModuleType.js
+++ b/packages/legacy-events/PluginModuleType.js
@@ -17,7 +17,7 @@ import type {EventSystemFlags} from 'legacy-events/EventSystemFlags';
 
 export type EventTypes = {[key: string]: DispatchConfig};
 
-export type AnyNativeEvent = Event | KeyboardEvent | MouseEvent | Touch;
+export type AnyNativeEvent = Event | KeyboardEvent | MouseEvent | TouchEvent;
 
 export type PluginName = string;
 

--- a/packages/legacy-events/ReactGenericBatching.js
+++ b/packages/legacy-events/ReactGenericBatching.js
@@ -10,7 +10,10 @@ import {
   restoreStateIfNeeded,
 } from './ReactControlledComponent';
 
-import {enableDeprecatedFlareAPI} from 'shared/ReactFeatureFlags';
+import {
+  enableDeprecatedFlareAPI,
+  enableListenerAPI,
+} from 'shared/ReactFeatureFlags';
 import {invokeGuardedCallbackAndCatchFirstError} from 'shared/ReactErrorUtils';
 
 // Used as a way to call batchedUpdates when we don't have a reference to
@@ -118,7 +121,7 @@ export function flushDiscreteUpdatesIfNeeded(timeStamp: number) {
   // behaviour as we had before this change, so the risks are low.
   if (
     !isInsideEventHandler &&
-    (!enableDeprecatedFlareAPI ||
+    ((!enableDeprecatedFlareAPI && !enableListenerAPI) ||
       (timeStamp === 0 || lastFlushedEventTimeStamp !== timeStamp))
   ) {
     lastFlushedEventTimeStamp = timeStamp;

--- a/packages/react-art/src/ReactARTHostConfig.js
+++ b/packages/react-art/src/ReactARTHostConfig.js
@@ -469,3 +469,26 @@ export function getInstanceFromNode(node) {
 export function beforeRemoveInstance(instance) {
   // noop
 }
+
+export function registerListenerEvent(
+  event: any,
+  rootContainerInstance: Container,
+): void {
+  // noop
+}
+
+export function attachListenerToInstance(listener: any): any {
+  // noop
+}
+
+export function detachListenerFromInstance(listener: any): any {
+  // noop
+}
+
+export function validateReactListenerDeleteListener(instance): void {
+  // noop
+}
+
+export function validateReactListenerMapListener(instance, listener): void {
+  // noop
+}

--- a/packages/react-debug-tools/src/ReactDebugHooks.js
+++ b/packages/react-debug-tools/src/ReactDebugHooks.js
@@ -238,6 +238,17 @@ function useResponder(
   };
 }
 
+const noOp = () => {};
+
+function useEvent(options: any): any {
+  hookLog.push({primitive: 'Event', stackError: new Error(), value: options});
+  return {
+    clear: noOp,
+    listen: noOp,
+    unlisten: noOp,
+  };
+}
+
 function useTransition(
   config: SuspenseConfig | null | void,
 ): [(() => void) => void, boolean] {
@@ -275,6 +286,7 @@ const Dispatcher: DispatcherType = {
   useResponder,
   useTransition,
   useDeferredValue,
+  useEvent,
 };
 
 // Inspect

--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -53,7 +53,10 @@ import {
 } from 'legacy-events/EventPropagators';
 import ReactVersion from 'shared/ReactVersion';
 import invariant from 'shared/invariant';
-import {exposeConcurrentModeAPIs} from 'shared/ReactFeatureFlags';
+import {
+  exposeConcurrentModeAPIs,
+  enableListenerAPI,
+} from 'shared/ReactFeatureFlags';
 
 import {
   getInstanceFromNode,
@@ -70,6 +73,7 @@ import {
   setAttemptHydrationAtCurrentPriority,
   queueExplicitHydrationTarget,
 } from '../events/ReactDOMEventReplaying';
+import {useEvent} from './ReactDOMEventListenerHooks';
 
 setAttemptSynchronousHydration(attemptSynchronousHydration);
 setAttemptUserBlockingHydration(attemptUserBlockingHydration);
@@ -191,6 +195,10 @@ if (exposeConcurrentModeAPIs) {
       queueExplicitHydrationTarget(target);
     }
   };
+}
+
+if (enableListenerAPI) {
+  ReactDOM.unstable_useEvent = useEvent;
 }
 
 const foundDevTools = injectIntoDevTools({

--- a/packages/react-dom/src/client/ReactDOMComponent.js
+++ b/packages/react-dom/src/client/ReactDOMComponent.js
@@ -65,6 +65,8 @@ import {
 import {
   addResponderEventSystemEvent,
   removeActiveResponderEventSystemEvent,
+  addListenerSystemEvent,
+  removeListenerSystemEvent,
 } from '../events/ReactDOMEventListener.js';
 import {mediaEventTypes} from '../events/DOMTopLevelEventTypes';
 import {
@@ -90,6 +92,7 @@ import {toStringOrTrustedType} from './ToStringValue';
 import {
   enableDeprecatedFlareAPI,
   enableTrustedTypesIntegration,
+  enableListenerAPI,
 } from 'shared/ReactFeatureFlags';
 
 let didWarnInvalidHydration = false;
@@ -1341,6 +1344,42 @@ export function listenToEventResponderEventTypes(
         );
         listenerMap.set(eventKey, eventListener);
       }
+    }
+  }
+}
+
+export function listenToEventListener(
+  type: string,
+  passive: boolean,
+  document: Document,
+): void {
+  if (enableListenerAPI) {
+    // Get the listening Map for this element. We use this to track
+    // what events we're listening to.
+    const listenerMap = getListenerMapForElement(document);
+    const passiveKey = type + '_passive';
+    const activeKey = type + '_active';
+    const eventKey = passive ? passiveKey : activeKey;
+
+    if (!listenerMap.has(eventKey)) {
+      if (passive) {
+        if (listenerMap.has(activeKey)) {
+          // If we have an active event listener, do not register
+          // a passive event listener. We use the same active event
+          // listener.
+          return;
+        } else {
+          // If we have a passive event listener, remove the
+          // existing passive event listener before we add the
+          // active event listener.
+          const passiveListener = listenerMap.get(passiveKey);
+          if (passiveListener != null) {
+            removeListenerSystemEvent(document, type, passiveListener);
+          }
+        }
+      }
+      const eventListener = addListenerSystemEvent(document, type, passive);
+      listenerMap.set(eventKey, eventListener);
     }
   }
 }

--- a/packages/react-dom/src/client/ReactDOMComponentTree.js
+++ b/packages/react-dom/src/client/ReactDOMComponentTree.js
@@ -20,6 +20,7 @@ const randomKey = Math.random()
   .slice(2);
 const internalInstanceKey = '__reactInternalInstance$' + randomKey;
 const internalEventHandlersKey = '__reactEventHandlers$' + randomKey;
+const internalEventListenersKey = '__reactEventListeners$' + randomKey;
 const internalContainerInstanceKey = '__reactContainere$' + randomKey;
 
 export function precacheFiberNode(hostInst, node) {
@@ -163,4 +164,12 @@ export function getFiberCurrentPropsFromNode(node) {
 
 export function updateFiberProps(node, props) {
   node[internalEventHandlersKey] = props;
+}
+
+export function getListenersFromNode(node) {
+  return node[internalEventListenersKey] || null;
+}
+
+export function initListenersSet(node, value) {
+  node[internalEventListenersKey] = value;
 }

--- a/packages/react-dom/src/client/ReactDOMEventListenerHooks.js
+++ b/packages/react-dom/src/client/ReactDOMEventListenerHooks.js
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type {
+  ReactDOMListenerEvent,
+  ReactDOMListenerMap,
+} from 'shared/ReactDOMTypes';
+
+import React from 'react';
+import invariant from 'shared/invariant';
+import {getEventPriority} from '../events/SimpleEventPlugin';
+
+const ReactCurrentDispatcher =
+  React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED
+    .ReactCurrentDispatcher;
+
+type EventOptions = {|
+  capture?: boolean,
+  passive?: boolean,
+  priority?: number,
+|};
+
+function resolveDispatcher() {
+  const dispatcher = ReactCurrentDispatcher.current;
+  invariant(
+    dispatcher !== null,
+    'Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for' +
+      ' one of the following reasons:\n' +
+      '1. You might have mismatching versions of React and the renderer (such as React DOM)\n' +
+      '2. You might be breaking the Rules of Hooks\n' +
+      '3. You might have more than one copy of React in the same app\n' +
+      'See https://fb.me/react-invalid-hook-call for tips about how to debug and fix this problem.',
+  );
+  return dispatcher;
+}
+
+export function useEvent(
+  type: string,
+  options?: EventOptions,
+): ReactDOMListenerMap {
+  const dispatcher = resolveDispatcher();
+  let capture = false;
+  let passive = false;
+  let priority = getEventPriority((type: any));
+
+  if (options != null) {
+    const optionsCapture = options && options.capture;
+    const optionsPassive = options && options.passive;
+    const optionsPriority = options && options.priority;
+
+    if (typeof optionsCapture === 'boolean') {
+      capture = optionsCapture;
+    }
+    if (typeof optionsPassive === 'boolean') {
+      passive = optionsPassive;
+    }
+    if (typeof optionsPriority === 'number') {
+      priority = optionsPriority;
+    }
+  }
+  const event: ReactDOMListenerEvent = {
+    capture,
+    passive,
+    priority,
+    type,
+  };
+  return dispatcher.useEvent(event);
+}

--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -11,6 +11,7 @@ import {
   precacheFiberNode,
   updateFiberProps,
   getClosestInstanceFromNode,
+  getListenersFromNode,
 } from './ReactDOMComponentTree';
 import {
   createElement,
@@ -27,6 +28,7 @@ import {
   warnForInsertedHydratedElement,
   warnForInsertedHydratedText,
   listenToEventResponderEventTypes,
+  listenToEventListener,
 } from './ReactDOMComponent';
 import {getSelectionInformation, restoreSelection} from './ReactInputSelection';
 import setTextContent from './setTextContent';
@@ -50,6 +52,9 @@ import type {
   ReactDOMEventResponder,
   ReactDOMEventResponderInstance,
   ReactDOMFundamentalComponentInstance,
+  ReactDOMListener,
+  ReactDOMListenerEvent,
+  ReactDOMListenerMap,
 } from 'shared/ReactDOMTypes';
 import {
   mountEventResponder,
@@ -57,6 +62,10 @@ import {
   DEPRECATED_dispatchEventForResponderEventSystem,
 } from '../events/DeprecatedDOMEventResponderSystem';
 import {retryIfBlockedOn} from '../events/ReactDOMEventReplaying';
+
+export type ReactListenerEvent = ReactDOMListenerEvent;
+export type ReactListenerMap = ReactDOMListenerMap;
+export type ReactListener = ReactDOMListener;
 
 export type Type = string;
 export type Props = {
@@ -113,11 +122,18 @@ import {
   enableSuspenseServerRenderer,
   enableDeprecatedFlareAPI,
   enableFundamentalAPI,
+  enableListenerAPI,
 } from 'shared/ReactFeatureFlags';
 import {
   RESPONDER_EVENT_SYSTEM,
   IS_PASSIVE,
 } from 'legacy-events/EventSystemFlags';
+import {
+  attachElementListener,
+  detachElementListener,
+  attachDocumentListener,
+  detachDocumentListener,
+} from '../events/DOMEventListenerSystem';
 
 let SUPPRESS_HYDRATION_WARNING;
 if (__DEV__) {
@@ -507,6 +523,22 @@ export function beforeRemoveInstance(
     instance === selectionInformation.focusedElem
   ) {
     dispatchBeforeDetachedBlur(((instance: any): HTMLElement));
+  }
+  if (enableListenerAPI) {
+    // It's unfortunate that we have to do this cleanup, but
+    // it's necessary otherwise we will leak the host instances
+    // from the useEvent hook instances Map. We call destroy
+    // on each listener to ensure we properly remove the instance
+    // from the instances Map. Note: we have this Map so that we
+    // can properly unmount instances when the function component
+    // that the hook is attached to gets unmounted.
+    const listenersSet = getListenersFromNode(instance);
+    if (listenersSet !== null) {
+      const listeners = Array.from(listenersSet);
+      for (let i = 0; i < listeners.length; i++) {
+        listeners[i].destroy();
+      }
+    }
   }
 }
 
@@ -1037,6 +1069,84 @@ export function unmountFundamentalComponent(
   }
 }
 
-export function getInstanceFromNode(node: HTMLElement): null | Object {
+export function getInstanceFromNode(node: Instance): null | Object {
   return getClosestInstanceFromNode(node) || null;
+}
+
+export function registerListenerEvent(
+  event: ReactDOMListenerEvent,
+  rootContainerInstance: Container,
+): void {
+  if (enableListenerAPI) {
+    const {type, passive} = event;
+    const doc = rootContainerInstance.ownerDocument;
+    listenToEventListener(type, passive, doc);
+  }
+}
+
+export function attachListenerToInstance(listener: ReactDOMListener): void {
+  if (enableListenerAPI) {
+    const {instance} = listener;
+    if (instance.nodeType === DOCUMENT_NODE) {
+      attachDocumentListener(listener);
+    } else {
+      attachElementListener(listener);
+    }
+  }
+}
+
+export function detachListenerFromInstance(listener: ReactDOMListener): void {
+  if (enableListenerAPI) {
+    const {instance} = listener;
+    if (instance.nodeType === DOCUMENT_NODE) {
+      detachDocumentListener(listener);
+    } else {
+      detachElementListener(listener);
+    }
+  }
+}
+
+function validateListenerInstance(instance, methodString): boolean {
+  if (
+    instance &&
+    (instance.nodeType === DOCUMENT_NODE ||
+      getClosestInstanceFromNode(instance))
+  ) {
+    return true;
+  }
+  if (__DEV__) {
+    console.warn(
+      'Event listener method %s() from useEvent() hook requires the first argument to be a valid' +
+        ' DOM node that was rendered and managed by React. If this is from a ref, ensure' +
+        ' the ref value has been set before attaching.',
+      methodString,
+    );
+  }
+  return false;
+}
+
+export function validateReactListenerDeleteListener(
+  instance: Container,
+): boolean {
+  return validateListenerInstance(instance, 'deleteListener');
+}
+
+export function validateReactListenerMapListener(
+  instance: Container,
+  listener: Event => void,
+): boolean {
+  if (enableListenerAPI) {
+    if (validateListenerInstance(instance, 'setListener')) {
+      if (typeof listener === 'function') {
+        return true;
+      }
+      if (__DEV__) {
+        console.warn(
+          'Event listener method setListener() from useEvent() hook requires the second argument' +
+            ' to be valid function callback.',
+        );
+      }
+    }
+  }
+  return false;
 }

--- a/packages/react-dom/src/events/DOMEventListenerSystem.js
+++ b/packages/react-dom/src/events/DOMEventListenerSystem.js
@@ -1,0 +1,353 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ * @flow
+ */
+
+import type {Fiber} from 'react-reconciler/src/ReactFiber';
+import type {ReactDOMListener} from 'shared/ReactDOMTypes';
+import type {AnyNativeEvent} from 'legacy-events/PluginModuleType';
+
+import {
+  ContinuousEvent,
+  UserBlockingEvent,
+  DiscreteEvent,
+} from 'shared/ReactTypes';
+import {HostComponent} from 'shared/ReactWorkTags';
+import {
+  batchedEventUpdates,
+  discreteUpdates,
+  flushDiscreteUpdatesIfNeeded,
+  executeUserEventHandler,
+} from 'legacy-events/ReactGenericBatching';
+
+// Intentionally not named imports because Rollup would use dynamic dispatch for
+// CommonJS interop named imports.
+import * as Scheduler from 'scheduler';
+import {enableListenerAPI} from 'shared/ReactFeatureFlags';
+import {
+  initListenersSet,
+  getListenersFromNode,
+} from '../client/ReactDOMComponentTree';
+
+const {
+  unstable_UserBlockingPriority: UserBlockingPriority,
+  unstable_runWithPriority: runWithPriority,
+} = Scheduler;
+const arrayFrom = Array.from;
+
+type EventProperties = {|
+  currentTarget: null | Document | Element,
+  eventPhase: number,
+  stopImmediatePropagation: boolean,
+  stopPropagation: boolean,
+|};
+
+const documentCaptureListeners = new Map();
+const documentBubbleListeners = new Map();
+
+function monkeyPatchNativeEvent(nativeEvent: any): EventProperties {
+  if (nativeEvent._reactEventProperties) {
+    const eventProperties = nativeEvent._reactEventProperties;
+    eventProperties.stopImmediatePropagation = false;
+    eventProperties.stopPropagation = false;
+    return eventProperties;
+  }
+  const eventProperties = {
+    currentTarget: null,
+    eventPhase: 0,
+    stopImmediatePropagation: false,
+    stopPropagation: false,
+  };
+  // $FlowFixMe: prevent Flow complaining about needing a value
+  Object.defineProperty(nativeEvent, 'currentTarget', {
+    get() {
+      return eventProperties.currentTarget;
+    },
+  });
+  // $FlowFixMe: prevent Flow complaning about needing a value
+  Object.defineProperty(nativeEvent, 'eventPhase', {
+    get() {
+      return eventProperties.eventPhase;
+    },
+  });
+  nativeEvent.stopPropagation = () => {
+    eventProperties.stopPropagation = true;
+  };
+  nativeEvent.stopImmediatePropagation = () => {
+    eventProperties.stopImmediatePropagation = true;
+    eventProperties.stopPropagation = true;
+  };
+  nativeEvent._reactEventProperties = eventProperties;
+  return eventProperties;
+}
+
+function getElementListeners(
+  eventType: string,
+  target: null | Fiber,
+): [Array<ReactDOMListener>, Array<ReactDOMListener>] {
+  const captureListeners = [];
+  const bubbleListeners = [];
+  let propagationDepth = 0;
+
+  let currentFiber = target;
+  while (currentFiber !== null) {
+    const {tag} = currentFiber;
+    if (tag === HostComponent) {
+      const hostInstance = currentFiber.stateNode;
+      const listenersSet = getListenersFromNode(hostInstance);
+
+      if (listenersSet !== null) {
+        const listeners = Array.from(listenersSet);
+        for (let i = 0; i < listeners.length; i++) {
+          const listener = listeners[i];
+          const {capture, type} = listener.event;
+          if (type === eventType) {
+            listener.depth = propagationDepth;
+            if (capture === true) {
+              captureListeners.push(listener);
+            } else {
+              bubbleListeners.push(listener);
+            }
+          }
+        }
+        propagationDepth++;
+      }
+    }
+    currentFiber = currentFiber.return;
+  }
+  return [captureListeners, bubbleListeners];
+}
+
+function getDocumentListenerSet(
+  type: string,
+  capture: boolean,
+): Set<ReactDOMListener> {
+  const delegatedEventListeners = capture
+    ? documentCaptureListeners
+    : documentBubbleListeners;
+  let listenersSet = delegatedEventListeners.get(type);
+
+  if (listenersSet === undefined) {
+    listenersSet = new Set();
+    delegatedEventListeners.set(type, listenersSet);
+  }
+  return listenersSet;
+}
+
+function dispatchListener(
+  listener: ReactDOMListener,
+  eventProperties: EventProperties,
+  nativeEvent: AnyNativeEvent,
+): void {
+  const callback = listener.callback;
+  eventProperties.currentTarget = listener.instance;
+  executeUserEventHandler(callback, nativeEvent);
+}
+
+function dispatchListenerAtPriority(
+  listener: ReactDOMListener,
+  eventProperties: EventProperties,
+  nativeEvent: AnyNativeEvent,
+) {
+  // The callback can either null or undefined, if so we skip dispatching it
+  if (listener.callback == null) {
+    return;
+  }
+  switch (listener.event.priority) {
+    case DiscreteEvent: {
+      flushDiscreteUpdatesIfNeeded(nativeEvent.timeStamp);
+      discreteUpdates(() =>
+        dispatchListener(listener, eventProperties, nativeEvent),
+      );
+      break;
+    }
+    case UserBlockingEvent: {
+      runWithPriority(UserBlockingPriority, () =>
+        dispatchListener(listener, eventProperties, nativeEvent),
+      );
+      break;
+    }
+    case ContinuousEvent: {
+      dispatchListener(listener, eventProperties, nativeEvent);
+      break;
+    }
+  }
+}
+
+function shouldStopPropagation(
+  eventProperties: EventProperties,
+  lastPropagationDepth: void | number,
+  propagationDepth: number,
+): boolean {
+  return (
+    (eventProperties.stopPropagation === true &&
+      lastPropagationDepth !== propagationDepth) ||
+    eventProperties.stopImmediatePropagation === true
+  );
+}
+
+function dispatchCaptureListeners(
+  eventProperties: EventProperties,
+  listeners: Array<ReactDOMListener>,
+  nativeEvent: AnyNativeEvent,
+  isDocumentListener: boolean,
+) {
+  const end = listeners.length - 1;
+  let lastPropagationDepth;
+  for (let i = end; i >= 0; i--) {
+    const listener = listeners[i];
+    const {depth} = listener;
+    if (
+      (!isDocumentListener || i === end) &&
+      shouldStopPropagation(eventProperties, lastPropagationDepth, depth)
+    ) {
+      return;
+    }
+    dispatchListenerAtPriority(listener, eventProperties, nativeEvent);
+    lastPropagationDepth = depth;
+  }
+}
+
+function dispatchBubbleListeners(
+  eventProperties: EventProperties,
+  listeners: Array<ReactDOMListener>,
+  nativeEvent: AnyNativeEvent,
+  isDocumentListener: boolean,
+) {
+  const length = listeners.length;
+  let lastPropagationDepth;
+  for (let i = 0; i < length; i++) {
+    const listener = listeners[i];
+    const {depth} = listener;
+    if (
+      // When document is not null, we know its a delegated event
+      (!isDocumentListener || i === 0) &&
+      shouldStopPropagation(eventProperties, lastPropagationDepth, depth)
+    ) {
+      return;
+    }
+    dispatchListenerAtPriority(listener, eventProperties, nativeEvent);
+    lastPropagationDepth = depth;
+  }
+}
+
+function dispatchListenersByPhase(
+  captureElementListeners: Array<ReactDOMListener>,
+  bubbleElementListeners: Array<ReactDOMListener>,
+  captureDocumentListeners: Array<ReactDOMListener>,
+  bubbleDocumentListeners: Array<ReactDOMListener>,
+  nativeEvent: AnyNativeEvent,
+): void {
+  const eventProperties = monkeyPatchNativeEvent(nativeEvent);
+  // Capture phase
+  eventProperties.eventPhase = 1;
+  // Dispatch capture delegated event listeners
+  dispatchCaptureListeners(
+    eventProperties,
+    captureDocumentListeners,
+    nativeEvent,
+    true,
+  );
+  // Dispatch capture target event listeners
+  dispatchCaptureListeners(
+    eventProperties,
+    captureElementListeners,
+    nativeEvent,
+    false,
+  );
+  eventProperties.stopPropagation = false;
+  eventProperties.stopImmediatePropagation = false;
+  // Bubble phase
+  eventProperties.eventPhase = 3;
+  // Dispatch bubble target event listeners
+  dispatchBubbleListeners(
+    eventProperties,
+    bubbleElementListeners,
+    nativeEvent,
+    false,
+  );
+  // Dispatch bubble delegated event listeners
+  dispatchBubbleListeners(
+    eventProperties,
+    bubbleDocumentListeners,
+    nativeEvent,
+    true,
+  );
+}
+
+export function dispatchEventForListenerEventSystem(
+  eventType: string,
+  targetFiber: null | Fiber,
+  nativeEvent: AnyNativeEvent,
+): void {
+  if (enableListenerAPI) {
+    // Get target event listeners in their propagation order (non delegated events)
+    const [
+      captureElementListeners,
+      bubbleElementListeners,
+    ] = getElementListeners(eventType, targetFiber);
+    const captureDocumentListeners = arrayFrom(
+      getDocumentListenerSet(eventType, true),
+    );
+    const bubbleDocumentListeners = arrayFrom(
+      getDocumentListenerSet(eventType, false),
+    );
+
+    if (
+      captureElementListeners.length !== 0 ||
+      bubbleElementListeners.length !== 0 ||
+      captureDocumentListeners.length !== 0 ||
+      bubbleDocumentListeners.length !== 0
+    ) {
+      batchedEventUpdates(() =>
+        dispatchListenersByPhase(
+          captureElementListeners,
+          bubbleElementListeners,
+          captureDocumentListeners,
+          bubbleDocumentListeners,
+          nativeEvent,
+        ),
+      );
+    }
+  }
+}
+
+function getDocumentListenerSetForListener(
+  listener: ReactDOMListener,
+): Set<ReactDOMListener> {
+  const {capture, type} = listener.event;
+  return getDocumentListenerSet(type, capture);
+}
+
+export function attachDocumentListener(listener: ReactDOMListener): void {
+  const documentListenersSet = getDocumentListenerSetForListener(listener);
+  documentListenersSet.add(listener);
+}
+
+export function detachDocumentListener(listener: ReactDOMListener): void {
+  const documentListenersSet = getDocumentListenerSetForListener(listener);
+  documentListenersSet.delete(listener);
+}
+
+export function attachElementListener(listener: ReactDOMListener): void {
+  const {instance} = listener;
+  let listeners = getListenersFromNode(instance);
+
+  if (listeners === null) {
+    listeners = new Set();
+    initListenersSet(instance, listeners);
+  }
+  listeners.add(listener);
+}
+
+export function detachElementListener(listener: ReactDOMListener): void {
+  const {instance} = listener;
+  const listeners = getListenersFromNode(instance);
+
+  if (listeners !== null) {
+    listeners.delete(listener);
+  }
+}

--- a/packages/react-dom/src/events/SimpleEventPlugin.js
+++ b/packages/react-dom/src/events/SimpleEventPlugin.js
@@ -240,10 +240,7 @@ const SimpleEventPlugin: PluginModule<MouseEvent> & {
 } = {
   eventTypes: eventTypes,
 
-  getEventPriority(topLevelType: TopLevelType): EventPriority {
-    const config = topLevelEventsToDispatchConfig[topLevelType];
-    return config !== undefined ? config.eventPriority : ContinuousEvent;
-  },
+  getEventPriority,
 
   extractEvents: function(
     topLevelType: TopLevelType,
@@ -363,5 +360,10 @@ const SimpleEventPlugin: PluginModule<MouseEvent> & {
     return event;
   },
 };
+
+export function getEventPriority(topLevelType: TopLevelType): EventPriority {
+  const config = topLevelEventsToDispatchConfig[topLevelType];
+  return config !== undefined ? config.eventPriority : ContinuousEvent;
+}
 
 export default SimpleEventPlugin;

--- a/packages/react-dom/src/events/__tests__/DOMEventListenerSystem-test.internal.js
+++ b/packages/react-dom/src/events/__tests__/DOMEventListenerSystem-test.internal.js
@@ -1,0 +1,752 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+let React;
+let ReactFeatureFlags;
+let ReactDOM;
+let ReactDOMServer;
+let Scheduler;
+
+function dispatchEvent(element, type) {
+  const event = document.createEvent('Event');
+  event.initEvent(type, true, true);
+  element.dispatchEvent(event);
+}
+
+function dispatchClickEvent(element) {
+  dispatchEvent(element, 'click');
+}
+
+describe('DOMEventListenerSystem', () => {
+  let container;
+
+  beforeEach(() => {
+    jest.resetModules();
+    ReactFeatureFlags = require('shared/ReactFeatureFlags');
+    ReactFeatureFlags.enableListenerAPI = true;
+    ReactFeatureFlags.enableScopeAPI = true;
+    React = require('react');
+    ReactDOM = require('react-dom');
+    ReactDOMServer = require('react-dom/server');
+    Scheduler = require('scheduler');
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+    container = null;
+  });
+
+  it('can render correctly with the ReactDOMServer', () => {
+    const clickEvent = jest.fn();
+
+    function Test() {
+      const divRef = React.useRef(null);
+      const click = ReactDOM.unstable_useEvent('click');
+
+      React.useEffect(() => {
+        click.setListener(divRef.current, clickEvent);
+      });
+
+      return <div ref={divRef}>Hello world</div>;
+    }
+    const output = ReactDOMServer.renderToString(<Test />);
+    expect(output).toBe(`<div data-reactroot="">Hello world</div>`);
+  });
+
+  it('can render correctly with the ReactDOMServer hydration', () => {
+    const clickEvent = jest.fn();
+    const spanRef = React.createRef();
+
+    function Test() {
+      const click = ReactDOM.unstable_useEvent('click');
+
+      React.useEffect(() => {
+        click.setListener(spanRef.current, clickEvent);
+      });
+
+      return (
+        <div>
+          <span ref={spanRef}>Hello world</span>
+        </div>
+      );
+    }
+    const output = ReactDOMServer.renderToString(<Test />);
+    expect(output).toBe(
+      `<div data-reactroot=""><span>Hello world</span></div>`,
+    );
+    container.innerHTML = output;
+    ReactDOM.hydrate(<Test />, container);
+    Scheduler.unstable_flushAll();
+    dispatchClickEvent(spanRef.current);
+    expect(clickEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it('should correctly work for a basic "click" listener', () => {
+    const log = [];
+    const clickEvent = jest.fn(event => {
+      log.push({
+        eventPhase: event.eventPhase,
+        type: event.type,
+        currentTarget: event.currentTarget,
+        target: event.target,
+      });
+    });
+    const divRef = React.createRef();
+    const buttonRef = React.createRef();
+
+    function Test() {
+      const click = ReactDOM.unstable_useEvent('click');
+
+      React.useEffect(() => {
+        click.setListener(buttonRef.current, clickEvent);
+      });
+
+      return (
+        <button ref={buttonRef}>
+          <div ref={divRef}>Click me!</div>
+        </button>
+      );
+    }
+
+    ReactDOM.render(<Test />, container);
+    Scheduler.unstable_flushAll();
+
+    expect(container.innerHTML).toBe('<button><div>Click me!</div></button>');
+
+    // Clicking the button should trigger the event callback
+    let divElement = divRef.current;
+    dispatchClickEvent(divElement);
+    expect(log[0]).toEqual({
+      eventPhase: 3,
+      type: 'click',
+      currentTarget: buttonRef.current,
+      target: divRef.current,
+    });
+
+    // Unmounting the container and clicking should not work
+    ReactDOM.render(null, container);
+    Scheduler.unstable_flushAll();
+
+    dispatchClickEvent(divElement);
+    expect(clickEvent).toBeCalledTimes(1);
+
+    // Re-rendering the container and clicking should work
+    ReactDOM.render(<Test />, container);
+    Scheduler.unstable_flushAll();
+
+    divElement = divRef.current;
+    dispatchClickEvent(divElement);
+    expect(clickEvent).toBeCalledTimes(2);
+
+    // Clicking the button should also work
+    let buttonElement = buttonRef.current;
+    dispatchClickEvent(buttonElement);
+    expect(log[2]).toEqual({
+      eventPhase: 3,
+      type: 'click',
+      currentTarget: buttonRef.current,
+      target: buttonRef.current,
+    });
+
+    function Test2({clickEvent2}) {
+      const click = ReactDOM.unstable_useEvent('click', clickEvent2);
+
+      React.useEffect(() => {
+        click.setListener(buttonRef.current, clickEvent2);
+      });
+
+      return (
+        <button ref={buttonRef}>
+          <div ref={divRef}>Click me!</div>
+        </button>
+      );
+    }
+
+    let clickEvent2 = jest.fn();
+    ReactDOM.render(<Test2 clickEvent2={clickEvent2} />, container);
+    Scheduler.unstable_flushAll();
+
+    divElement = divRef.current;
+    dispatchClickEvent(divElement);
+    expect(clickEvent2).toBeCalledTimes(1);
+
+    // Reset the function we pass in, so it's different
+    clickEvent2 = jest.fn();
+    ReactDOM.render(<Test2 clickEvent2={clickEvent2} />, container);
+    Scheduler.unstable_flushAll();
+
+    divElement = divRef.current;
+    dispatchClickEvent(divElement);
+    expect(clickEvent2).toBeCalledTimes(1);
+  });
+
+  it('should correctly work for a basic "click" listener on the outer target', () => {
+    const log = [];
+    const clickEvent = jest.fn(event => {
+      log.push({
+        eventPhase: event.eventPhase,
+        type: event.type,
+        currentTarget: event.currentTarget,
+        target: event.target,
+      });
+    });
+    const divRef = React.createRef();
+    const buttonRef = React.createRef();
+
+    function Test() {
+      const click = ReactDOM.unstable_useEvent('click');
+
+      React.useEffect(() => {
+        click.setListener(divRef.current, clickEvent);
+      });
+
+      return (
+        <button ref={buttonRef}>
+          <div ref={divRef}>Click me!</div>
+        </button>
+      );
+    }
+
+    ReactDOM.render(<Test />, container);
+    Scheduler.unstable_flushAll();
+
+    expect(container.innerHTML).toBe('<button><div>Click me!</div></button>');
+
+    // Clicking the button should trigger the event callback
+    let divElement = divRef.current;
+    dispatchClickEvent(divElement);
+    expect(log[0]).toEqual({
+      eventPhase: 3,
+      type: 'click',
+      currentTarget: divRef.current,
+      target: divRef.current,
+    });
+
+    // Unmounting the container and clicking should not work
+    ReactDOM.render(null, container);
+    dispatchClickEvent(divElement);
+    expect(clickEvent).toBeCalledTimes(1);
+
+    // Re-rendering the container and clicking should work
+    ReactDOM.render(<Test />, container);
+    Scheduler.unstable_flushAll();
+
+    divElement = divRef.current;
+    dispatchClickEvent(divElement);
+    expect(clickEvent).toBeCalledTimes(2);
+
+    // Clicking the button should not work
+    let buttonElement = buttonRef.current;
+    dispatchClickEvent(buttonElement);
+    expect(clickEvent).toBeCalledTimes(2);
+  });
+
+  it('should correctly handle many nested target listeners', () => {
+    const buttonRef = React.createRef();
+    const targetListerner1 = jest.fn();
+    const targetListerner2 = jest.fn();
+    const targetListerner3 = jest.fn();
+    const targetListerner4 = jest.fn();
+
+    function Test() {
+      const click1 = ReactDOM.unstable_useEvent('click', {capture: true});
+      const click2 = ReactDOM.unstable_useEvent('click', {capture: true});
+      const click3 = ReactDOM.unstable_useEvent('click');
+      const click4 = ReactDOM.unstable_useEvent('click');
+
+      React.useEffect(() => {
+        click1.setListener(buttonRef.current, targetListerner1);
+        click2.setListener(buttonRef.current, targetListerner2);
+        click3.setListener(buttonRef.current, targetListerner3);
+        click4.setListener(buttonRef.current, targetListerner4);
+      });
+
+      return <button ref={buttonRef}>Click me!</button>;
+    }
+
+    ReactDOM.render(<Test />, container);
+    Scheduler.unstable_flushAll();
+
+    let buttonElement = buttonRef.current;
+    dispatchClickEvent(buttonElement);
+
+    expect(targetListerner1).toHaveBeenCalledTimes(1);
+    expect(targetListerner2).toHaveBeenCalledTimes(1);
+    expect(targetListerner3).toHaveBeenCalledTimes(1);
+    expect(targetListerner4).toHaveBeenCalledTimes(1);
+
+    function Test2() {
+      const click1 = ReactDOM.unstable_useEvent('click');
+      const click2 = ReactDOM.unstable_useEvent('click');
+      const click3 = ReactDOM.unstable_useEvent('click');
+      const click4 = ReactDOM.unstable_useEvent('click');
+
+      React.useEffect(() => {
+        click1.setListener(buttonRef.current, targetListerner1);
+        click2.setListener(buttonRef.current, targetListerner2);
+        click3.setListener(buttonRef.current, targetListerner3);
+        click4.setListener(buttonRef.current, targetListerner4);
+      });
+
+      return <button ref={buttonRef}>Click me!</button>;
+    }
+
+    ReactDOM.render(<Test2 />, container);
+    Scheduler.unstable_flushAll();
+
+    buttonElement = buttonRef.current;
+    dispatchClickEvent(buttonElement);
+    expect(targetListerner1).toHaveBeenCalledTimes(2);
+    expect(targetListerner2).toHaveBeenCalledTimes(2);
+    expect(targetListerner3).toHaveBeenCalledTimes(2);
+    expect(targetListerner4).toHaveBeenCalledTimes(2);
+  });
+
+  it('should correctly work for a basic "click" document listener', () => {
+    const log = [];
+    const clickEvent = jest.fn(event => {
+      log.push({
+        eventPhase: event.eventPhase,
+        type: event.type,
+        currentTarget: event.currentTarget,
+        target: event.target,
+      });
+    });
+
+    function Test() {
+      const click = ReactDOM.unstable_useEvent('click');
+
+      React.useEffect(() => {
+        click.setListener(document, clickEvent);
+      });
+
+      return <button>Click anything!</button>;
+    }
+    ReactDOM.render(<Test />, container);
+    Scheduler.unstable_flushAll();
+
+    expect(container.innerHTML).toBe('<button>Click anything!</button>');
+
+    // Clicking outside the button should trigger the event callback
+    dispatchClickEvent(document.body);
+    expect(log[0]).toEqual({
+      eventPhase: 3,
+      type: 'click',
+      currentTarget: document,
+      target: document.body,
+    });
+
+    // Unmounting the container and clicking should not work
+    ReactDOM.render(null, container);
+    Scheduler.unstable_flushAll();
+
+    dispatchClickEvent(document.body);
+    expect(clickEvent).toBeCalledTimes(1);
+
+    // Re-rendering and clicking the body should work again
+    ReactDOM.render(<Test />, container);
+    Scheduler.unstable_flushAll();
+
+    dispatchClickEvent(document.body);
+    expect(clickEvent).toBeCalledTimes(2);
+  });
+
+  it('should correctly handle event propagation in the correct order', () => {
+    const buttonRef = React.createRef();
+    const divRef = React.createRef();
+    const log = [];
+
+    function Test() {
+      // Document
+      const click1 = ReactDOM.unstable_useEvent('click', {capture: true});
+      const click2 = ReactDOM.unstable_useEvent('click');
+      // Div
+      const click3 = ReactDOM.unstable_useEvent('click');
+      const click4 = ReactDOM.unstable_useEvent('click', {capture: true});
+      // Button
+      const click5 = ReactDOM.unstable_useEvent('click');
+      const click6 = ReactDOM.unstable_useEvent('click', {capture: true});
+
+      React.useEffect(() => {
+        click1.setListener(document, e => {
+          log.push({
+            bound: false,
+            delegated: true,
+            eventPhase: e.eventPhase,
+            currentTarget: e.currentTarget,
+            target: e.target,
+          });
+        });
+        click2.setListener(document, e => {
+          log.push({
+            bound: false,
+            delegated: true,
+            eventPhase: e.eventPhase,
+            currentTarget: e.currentTarget,
+            target: e.target,
+          });
+        });
+        click3.setListener(divRef.current, e => {
+          log.push({
+            bound: true,
+            delegated: false,
+            eventPhase: e.eventPhase,
+            currentTarget: e.currentTarget,
+            target: e.target,
+          });
+        });
+        click4.setListener(divRef.current, e => {
+          log.push({
+            bound: true,
+            delegated: false,
+            eventPhase: e.eventPhase,
+            currentTarget: e.currentTarget,
+            target: e.target,
+          });
+        });
+        click5.setListener(buttonRef.current, e => {
+          log.push({
+            bound: true,
+            delegated: false,
+            eventPhase: e.eventPhase,
+            currentTarget: e.currentTarget,
+            target: e.target,
+          });
+        });
+        click6.setListener(buttonRef.current, e => {
+          log.push({
+            bound: true,
+            delegated: false,
+            eventPhase: e.eventPhase,
+            currentTarget: e.currentTarget,
+            target: e.target,
+          });
+        });
+      });
+
+      return (
+        <button ref={buttonRef}>
+          <div ref={divRef}>Click me!</div>
+        </button>
+      );
+    }
+
+    ReactDOM.render(<Test />, container);
+    Scheduler.unstable_flushAll();
+
+    let divElement = divRef.current;
+    dispatchClickEvent(divElement);
+
+    expect(log).toEqual([
+      {
+        bound: false,
+        delegated: true,
+        eventPhase: 1,
+        currentTarget: document,
+        target: divRef.current,
+      },
+      {
+        bound: true,
+        delegated: false,
+        eventPhase: 1,
+        currentTarget: buttonRef.current,
+        target: divRef.current,
+      },
+      {
+        bound: true,
+        delegated: false,
+        eventPhase: 1,
+        currentTarget: divRef.current,
+        target: divRef.current,
+      },
+      {
+        bound: true,
+        delegated: false,
+        eventPhase: 3,
+        currentTarget: divRef.current,
+        target: divRef.current,
+      },
+      {
+        bound: true,
+        delegated: false,
+        eventPhase: 3,
+        currentTarget: buttonRef.current,
+        target: divRef.current,
+      },
+      {
+        bound: false,
+        delegated: true,
+        eventPhase: 3,
+        currentTarget: document,
+        target: divRef.current,
+      },
+    ]);
+  });
+
+  it('should correctly handle stopImmediatePropagation for mixed listeners', () => {
+    const buttonRef = React.createRef();
+    const targetListerner1 = jest.fn(e => e.stopImmediatePropagation());
+    const targetListerner2 = jest.fn(e => e.stopImmediatePropagation());
+    const rootListerner1 = jest.fn();
+
+    function Test() {
+      const click1 = ReactDOM.unstable_useEvent('click', {capture: true});
+      const click2 = ReactDOM.unstable_useEvent('click');
+      const click3 = ReactDOM.unstable_useEvent('click');
+
+      React.useEffect(() => {
+        click1.setListener(buttonRef.current, targetListerner1);
+        click2.setListener(buttonRef.current, targetListerner2);
+        click3.setListener(document, targetListerner1);
+      });
+
+      return <button ref={buttonRef}>Click me!</button>;
+    }
+
+    ReactDOM.render(<Test />, container);
+    Scheduler.unstable_flushAll();
+
+    let buttonElement = buttonRef.current;
+    dispatchClickEvent(buttonElement);
+    expect(targetListerner1).toHaveBeenCalledTimes(1);
+    expect(targetListerner2).toHaveBeenCalledTimes(1);
+    expect(rootListerner1).toHaveBeenCalledTimes(0);
+  });
+
+  it('should correctly handle stopPropagation for based target events', () => {
+    const buttonRef = React.createRef();
+    const divRef = React.createRef();
+    let clickEvent = jest.fn();
+
+    function Test() {
+      const click1 = ReactDOM.unstable_useEvent('click', {
+        bind: buttonRef,
+      });
+      const click2 = ReactDOM.unstable_useEvent('click');
+
+      React.useEffect(() => {
+        click1.setListener(buttonRef.current, clickEvent);
+        click2.setListener(divRef.current, e => {
+          e.stopPropagation();
+        });
+      });
+
+      return (
+        <button ref={buttonRef}>
+          <div ref={divRef}>Click me!</div>
+        </button>
+      );
+    }
+
+    ReactDOM.render(<Test />, container);
+    Scheduler.unstable_flushAll();
+
+    let divElement = divRef.current;
+    dispatchClickEvent(divElement);
+    expect(clickEvent).toHaveBeenCalledTimes(0);
+  });
+
+  it('should correctly handle stopPropagation for mixed capture/bubbling target listeners', () => {
+    const buttonRef = React.createRef();
+    const targetListerner1 = jest.fn(e => e.stopPropagation());
+    const targetListerner2 = jest.fn(e => e.stopPropagation());
+    const targetListerner3 = jest.fn(e => e.stopPropagation());
+    const targetListerner4 = jest.fn(e => e.stopPropagation());
+
+    function Test() {
+      const click1 = ReactDOM.unstable_useEvent('click', {capture: true});
+      const click2 = ReactDOM.unstable_useEvent('click', {capture: true});
+      const click3 = ReactDOM.unstable_useEvent('click');
+      const click4 = ReactDOM.unstable_useEvent('click');
+
+      React.useEffect(() => {
+        click1.setListener(buttonRef.current, targetListerner1);
+        click2.setListener(buttonRef.current, targetListerner2);
+        click3.setListener(buttonRef.current, targetListerner3);
+        click4.setListener(buttonRef.current, targetListerner4);
+      });
+
+      return <button ref={buttonRef}>Click me!</button>;
+    }
+
+    ReactDOM.render(<Test />, container);
+    Scheduler.unstable_flushAll();
+
+    let buttonElement = buttonRef.current;
+    dispatchClickEvent(buttonElement);
+    expect(targetListerner1).toHaveBeenCalledTimes(1);
+    expect(targetListerner2).toHaveBeenCalledTimes(1);
+    expect(targetListerner3).toHaveBeenCalledTimes(1);
+    expect(targetListerner4).toHaveBeenCalledTimes(1);
+  });
+
+  it('should correctly handle stopPropagation for target listeners', () => {
+    const buttonRef = React.createRef();
+    const targetListerner1 = jest.fn(e => e.stopPropagation());
+    const targetListerner2 = jest.fn(e => e.stopPropagation());
+    const targetListerner3 = jest.fn(e => e.stopPropagation());
+    const targetListerner4 = jest.fn(e => e.stopPropagation());
+
+    function Test() {
+      const click1 = ReactDOM.unstable_useEvent('click');
+      const click2 = ReactDOM.unstable_useEvent('click');
+      const click3 = ReactDOM.unstable_useEvent('click');
+      const click4 = ReactDOM.unstable_useEvent('click');
+
+      React.useEffect(() => {
+        click1.setListener(buttonRef.current, targetListerner1);
+        click2.setListener(buttonRef.current, targetListerner2);
+        click3.setListener(buttonRef.current, targetListerner3);
+        click4.setListener(buttonRef.current, targetListerner4);
+      });
+
+      return <button ref={buttonRef}>Click me!</button>;
+    }
+
+    ReactDOM.render(<Test />, container);
+    Scheduler.unstable_flushAll();
+
+    let buttonElement = buttonRef.current;
+    dispatchClickEvent(buttonElement);
+    expect(targetListerner1).toHaveBeenCalledTimes(1);
+    expect(targetListerner2).toHaveBeenCalledTimes(1);
+    expect(targetListerner3).toHaveBeenCalledTimes(1);
+    expect(targetListerner4).toHaveBeenCalledTimes(1);
+  });
+
+  it('should correctly handle stopPropagation for mixed listeners', () => {
+    const buttonRef = React.createRef();
+    const rootListerner1 = jest.fn(e => e.stopPropagation());
+    const rootListerner2 = jest.fn();
+    const targetListerner1 = jest.fn();
+    const targetListerner2 = jest.fn(e => e.stopPropagation());
+
+    function Test() {
+      const click1 = ReactDOM.unstable_useEvent('click', {capture: true});
+      const click2 = ReactDOM.unstable_useEvent('click', {capture: true});
+      const click3 = ReactDOM.unstable_useEvent('click');
+      const click4 = ReactDOM.unstable_useEvent('click');
+
+      React.useEffect(() => {
+        click1.setListener(document, rootListerner1);
+        click2.setListener(buttonRef.current, targetListerner1);
+        click3.setListener(document, rootListerner2);
+        click4.setListener(buttonRef.current, targetListerner2);
+      });
+
+      return <button ref={buttonRef}>Click me!</button>;
+    }
+
+    ReactDOM.render(<Test />, container);
+    Scheduler.unstable_flushAll();
+
+    let buttonElement = buttonRef.current;
+    dispatchClickEvent(buttonElement);
+    expect(rootListerner1).toHaveBeenCalledTimes(1);
+    expect(targetListerner1).toHaveBeenCalledTimes(0);
+    expect(targetListerner2).toHaveBeenCalledTimes(1);
+    expect(rootListerner2).toHaveBeenCalledTimes(0);
+  });
+
+  it('should correctly handle stopPropagation for delegated listeners', () => {
+    const buttonRef = React.createRef();
+    const rootListerner1 = jest.fn(e => e.stopPropagation());
+    const rootListerner2 = jest.fn();
+    const rootListerner3 = jest.fn(e => e.stopPropagation());
+    const rootListerner4 = jest.fn();
+
+    function Test() {
+      const click1 = ReactDOM.unstable_useEvent('click', {capture: true});
+      const click2 = ReactDOM.unstable_useEvent('click', {capture: true});
+      const click3 = ReactDOM.unstable_useEvent('click');
+      const click4 = ReactDOM.unstable_useEvent('click');
+
+      React.useEffect(() => {
+        click1.setListener(document, rootListerner1);
+        click2.setListener(document, rootListerner2);
+        click3.setListener(document, rootListerner3);
+        click4.setListener(document, rootListerner4);
+      });
+
+      return <button ref={buttonRef}>Click me!</button>;
+    }
+
+    ReactDOM.render(<Test />, container);
+
+    Scheduler.unstable_flushAll();
+
+    let buttonElement = buttonRef.current;
+    dispatchClickEvent(buttonElement);
+    expect(rootListerner1).toHaveBeenCalledTimes(1);
+    expect(rootListerner2).toHaveBeenCalledTimes(1);
+    expect(rootListerner3).toHaveBeenCalledTimes(1);
+    expect(rootListerner4).toHaveBeenCalledTimes(1);
+  });
+
+  it.experimental('should work with concurrent mode updates', async () => {
+    const log = [];
+    const ref = React.createRef();
+
+    function Test({counter}) {
+      const click = ReactDOM.unstable_useEvent('click');
+
+      React.useLayoutEffect(() => {
+        click.setListener(ref.current, () => {
+          log.push({counter});
+        });
+      });
+
+      Scheduler.unstable_yieldValue('Test');
+      return <button ref={ref}>Press me</button>;
+    }
+
+    let root = ReactDOM.createRoot(container);
+    root.render(<Test counter={0} />);
+
+    // Dev double-render
+    if (__DEV__) {
+      expect(Scheduler).toFlushAndYield(['Test', 'Test']);
+    } else {
+      expect(Scheduler).toFlushAndYield(['Test']);
+    }
+
+    // Click the button
+    dispatchClickEvent(ref.current);
+    expect(log).toEqual([{counter: 0}]);
+
+    // Clear log
+    log.length = 0;
+
+    // Increase counter
+    root.render(<Test counter={1} />);
+    // Yield before committing
+    // Dev double-render
+    if (__DEV__) {
+      expect(Scheduler).toFlushAndYieldThrough(['Test', 'Test']);
+    } else {
+      expect(Scheduler).toFlushAndYieldThrough(['Test']);
+    }
+
+    // Click the button again
+    dispatchClickEvent(ref.current);
+    expect(log).toEqual([{counter: 0}]);
+
+    // Clear log
+    log.length = 0;
+
+    // Commit
+    expect(Scheduler).toFlushAndYield([]);
+    dispatchClickEvent(ref.current);
+    expect(log).toEqual([{counter: 1}]);
+  });
+});

--- a/packages/react-dom/src/server/ReactPartialRendererHooks.js
+++ b/packages/react-dom/src/server/ReactPartialRendererHooks.js
@@ -473,6 +473,14 @@ function useTransition(
   return [startTransition, false];
 }
 
+function useEvent(options: any): any {
+  return {
+    clear: noop,
+    deleteListener: noop,
+    setListener: noop,
+  };
+}
+
 function noop(): void {}
 
 export let currentThreadID: ThreadID = 0;
@@ -499,4 +507,5 @@ export const Dispatcher: DispatcherType = {
   useResponder,
   useDeferredValue,
   useTransition,
+  useEvent,
 };

--- a/packages/react-native-renderer/src/ReactFabricHostConfig.js
+++ b/packages/react-native-renderer/src/ReactFabricHostConfig.js
@@ -54,6 +54,11 @@ const {get: getViewConfigForType} = ReactNativeViewConfigRegistry;
 let nextReactTag = 2;
 
 type Node = Object;
+
+export type ReactListenerEvent = Object;
+export type ReactListenerMap = Object;
+export type ReactListener = Object;
+
 export type Type = string;
 export type Props = Object;
 export type Instance = {
@@ -466,5 +471,25 @@ export function getInstanceFromNode(node) {
 }
 
 export function beforeRemoveInstance(instance) {
+  // noop
+}
+
+export function registerListenerEvent(instance, event, callback): void {
+  // noop
+}
+
+export function attachListenerToInstance(linstance, event, callback): any {
+  // noop
+}
+
+export function detachListenerFromInstance(instance, event, callback): any {
+  // noop
+}
+
+export function validateReactListenerDeleteListener(instance): void {
+  // noop
+}
+
+export function validateReactListenerMapListener(instance, listener): void {
   // noop
 }

--- a/packages/react-native-renderer/src/ReactNativeHostConfig.js
+++ b/packages/react-native-renderer/src/ReactNativeHostConfig.js
@@ -28,6 +28,10 @@ import ReactNativeFiberHostComponent from './ReactNativeFiberHostComponent';
 
 const {get: getViewConfigForType} = ReactNativeViewConfigRegistry;
 
+export type ReactListenerEvent = Object;
+export type ReactListenerMap = Object;
+export type ReactListener = Object;
+
 export type Type = string;
 export type Props = Object;
 export type Container = number;
@@ -518,5 +522,25 @@ export function getInstanceFromNode(node) {
 }
 
 export function beforeRemoveInstance(instance) {
+  // noop
+}
+
+export function registerListenerEvent(instance, event, callback): void {
+  // noop
+}
+
+export function attachListenerToInstance(linstance, event, callback): any {
+  // noop
+}
+
+export function detachListenerFromInstance(instance, event, callback): any {
+  // noop
+}
+
+export function validateReactListenerDeleteListener(instance): void {
+  // noop
+}
+
+export function validateReactListenerMapListener(instance, listener): void {
   // noop
 }

--- a/packages/react-reconciler/src/forks/ReactFiberHostConfig.custom.js
+++ b/packages/react-reconciler/src/forks/ReactFiberHostConfig.custom.js
@@ -37,6 +37,9 @@ export opaque type UpdatePayload = mixed; // eslint-disable-line no-undef
 export opaque type ChildSet = mixed; // eslint-disable-line no-undef
 export opaque type TimeoutHandle = mixed; // eslint-disable-line no-undef
 export opaque type NoTimeout = mixed; // eslint-disable-line no-undef
+export type ReactListenerEvent = Object;
+export type ReactListenerMap = Object;
+export type ReactListener = Object;
 export type EventResponder = any;
 
 export const getPublicInstance = $$$hostConfig.getPublicInstance;
@@ -73,6 +76,11 @@ export const shouldUpdateFundamentalComponent =
   $$$hostConfig.shouldUpdateFundamentalComponent;
 export const getInstanceFromNode = $$$hostConfig.getInstanceFromNode;
 export const beforeRemoveInstance = $$$hostConfig.beforeRemoveInstance;
+export const registerListenerEvent = $$$hostConfig.registerListenerEvent;
+export const validateReactListenerDeleteListener =
+  $$$hostConfig.validateReactListenerDeleteListener;
+export const validateReactListenerMapListener =
+  $$$hostConfig.validateReactListenerMapListener;
 
 // -------------------
 //      Mutation
@@ -96,6 +104,9 @@ export const updateFundamentalComponent =
   $$$hostConfig.updateFundamentalComponent;
 export const unmountFundamentalComponent =
   $$$hostConfig.unmountFundamentalComponent;
+export const attachListenerToInstance = $$$hostConfig.attachListenerToInstance;
+export const detachListenerFromInstance =
+  $$$hostConfig.detachListenerFromInstance;
 
 // -------------------
 //     Persistence

--- a/packages/react-test-renderer/src/ReactShallowRenderer.js
+++ b/packages/react-test-renderer/src/ReactShallowRenderer.js
@@ -395,6 +395,14 @@ class ReactShallowRenderer {
       return value;
     };
 
+    const useEvent = () => {
+      return {
+        clear: noOp,
+        deleteListener: noOp,
+        setListener: noOp,
+      };
+    };
+
     return {
       readContext,
       useCallback: (identity: any),
@@ -413,6 +421,7 @@ class ReactShallowRenderer {
       useResponder,
       useTransition,
       useDeferredValue,
+      useEvent,
     };
   }
 

--- a/packages/react-test-renderer/src/ReactTestHostConfig.js
+++ b/packages/react-test-renderer/src/ReactTestHostConfig.js
@@ -15,6 +15,10 @@ import type {
 
 import {enableDeprecatedFlareAPI} from 'shared/ReactFeatureFlags';
 
+export type ReactListenerEvent = Object;
+export type ReactListenerMap = Object;
+export type ReactListener = Object;
+
 export type Type = string;
 export type Props = Object;
 export type Container = {|
@@ -371,5 +375,25 @@ export function getInstanceFromNode(mockNode: Object) {
 }
 
 export function beforeRemoveInstance(instance) {
+  // noop
+}
+
+export function registerListenerEvent(instance, event, callback): void {
+  // noop
+}
+
+export function attachListenerToInstance(linstance, event, callback): any {
+  // noop
+}
+
+export function detachListenerFromInstance(instance, event, callback): any {
+  // noop
+}
+
+export function validateReactListenerDeleteListener(instance): void {
+  // noop
+}
+
+export function validateReactListenerMapListener(instance, listener): void {
   // noop
 }

--- a/packages/shared/ReactDOMTypes.js
+++ b/packages/shared/ReactDOMTypes.js
@@ -73,3 +73,29 @@ export type ReactDOMResponderContext = {
   enqueueStateRestore(Element | Document): void,
   getResponderNode(): Element | null,
 };
+
+export type RefObject = {current: null | mixed};
+
+export type ReactDOMListenerEvent = {|
+  capture: boolean,
+  passive: boolean,
+  priority: number,
+  type: string,
+|};
+
+export type ReactDOMListenerMap = {|
+  clear: () => void,
+  setListener: (
+    instance: Document | HTMLElement,
+    callback: (Event) => void,
+  ) => void,
+  deleteListener: (instance: Document | HTMLElement) => void,
+|};
+
+export type ReactDOMListener = {|
+  callback: Event => void,
+  depth: number,
+  destroy: Document | (Element => void),
+  event: ReactDOMListenerEvent,
+  instance: Document | Element,
+|};

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -54,8 +54,11 @@ export const exposeConcurrentModeAPIs = __EXPERIMENTAL__;
 
 export const warnAboutShorthandPropertyCollision = false;
 
-// Experimental React Flare event system and event components support.
+// Experimental React Flare event system.
 export const enableDeprecatedFlareAPI = false;
+
+// Experimental Listener system.
+export const enableListenerAPI = false;
 
 // Experimental Host Component support.
 export const enableFundamentalAPI = false;

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -33,6 +33,7 @@ export const disableInputAttributeSyncing = false;
 export const replayFailedUnitOfWorkWithInvokeGuardedCallback = __DEV__;
 export const warnAboutDeprecatedLifecycles = true;
 export const enableDeprecatedFlareAPI = false;
+export const enableListenerAPI = false;
 export const enableFundamentalAPI = false;
 export const enableScopeAPI = false;
 export const enableJSXTransformAPI = false;

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -27,6 +27,7 @@ export const exposeConcurrentModeAPIs = __EXPERIMENTAL__;
 export const warnAboutShorthandPropertyCollision = false;
 export const enableSchedulerDebugging = false;
 export const enableDeprecatedFlareAPI = false;
+export const enableListenerAPI = false;
 export const enableFundamentalAPI = false;
 export const enableScopeAPI = false;
 export const enableJSXTransformAPI = false;

--- a/packages/shared/forks/ReactFeatureFlags.persistent.js
+++ b/packages/shared/forks/ReactFeatureFlags.persistent.js
@@ -27,6 +27,7 @@ export const exposeConcurrentModeAPIs = __EXPERIMENTAL__;
 export const warnAboutShorthandPropertyCollision = false;
 export const enableSchedulerDebugging = false;
 export const enableDeprecatedFlareAPI = false;
+export const enableListenerAPI = false;
 export const enableFundamentalAPI = false;
 export const enableScopeAPI = false;
 export const enableJSXTransformAPI = false;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -27,6 +27,7 @@ export const exposeConcurrentModeAPIs = __EXPERIMENTAL__;
 export const warnAboutShorthandPropertyCollision = false;
 export const enableSchedulerDebugging = false;
 export const enableDeprecatedFlareAPI = false;
+export const enableListenerAPI = false;
 export const enableFundamentalAPI = false;
 export const enableScopeAPI = false;
 export const enableJSXTransformAPI = false;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -25,6 +25,7 @@ export const exposeConcurrentModeAPIs = __EXPERIMENTAL__;
 export const enableSchedulerDebugging = false;
 export const disableJavaScriptURLs = false;
 export const enableDeprecatedFlareAPI = true;
+export const enableListenerAPI = false;
 export const enableFundamentalAPI = false;
 export const enableScopeAPI = true;
 export const enableJSXTransformAPI = true;

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -76,6 +76,8 @@ function updateFlagOutsideOfReactCallStack() {
 
 export const enableDeprecatedFlareAPI = true;
 
+export const enableListenerAPI = true;
+
 export const enableFundamentalAPI = false;
 
 export const enableScopeAPI = true;


### PR DESCRIPTION
Mirror of facebook react#17651
Note: This API is intentionally meant to be a low-level way of creating events and assigning listeners to them. It's meant to be verbose so larger building blocks can be created on top of them.

This PR is an alternative solution and system to that of my other PR: https://github.com/facebook/react/pull/17508. Specifically, based off feedback internally, I've tried to tackle some of the problems that were brought up with the `createListener` approach in https://github.com/facebook/react/pull/17508:

- `createListener` largely depended on events being registered in the commit phase, meaning that there would likely be issues around needing to flush more to ensure we register DOM events. The new approach enforces all events are registered unconditionally via hooks in the render phase, mitigating this issue.
- `createListener` allowed for listeners to update and change their properties between renders, which again is problematic for performance and would also require more flushes to ensure we have committed the latest version of each listener.
- `createListener` had a complex diffing process to ensure we stored the latest listeners, but this meant that the process had additional overhead and memory usage – which is no longer the case with this PR.
- `createListener` required listeners to be put on nodes via the `listeners` prop. Furthermore, it required using arrays to combine multiple listeners, which some felt was not idealistic and might be confusing during debugging as to which listeners occured at which stages. Also, there was general dislike to introducing another internal prop – as it would mean we'd have to first forbid `listeners` and wait for React 17 to introduce these APIs, as they might be used in the wild for other reasons (custom elements).
- `createListener` didn't provide an idiomatic way to conditionally add/remove root events (they're called delegated events in this new PR). With the new approach, there's a streamlined approach to ensure this is easier to do, and by default, no root events can be added unconditonally, which is a code-smell and a good cause of memory leaks/performance issues.

Taking the above points into consideration, the design of this new event system aims at bringing the same capabilities as described in https://github.com/facebook/react/pull/17508 whilst also providing some other nice features, that should allow for bigger event sub-systems to be built on top.

## `ReactDOM.useEvent`

This hook allows for the registration to a native DOM event, similar to that of `addEventListener` on the web. `useEvent` takes a given event `type` and registers it to the DOM then returns an object unique to that event that allows listeners to be attached to their targets in an effect or another event handler. The object provides three different methods to setup and handle listeners:

- `setListener(target: document | element, listener: Event => void)` set a listener to be active for a given DOM node. The node must be a DOM node managed by React or it can be the `document` node for delegation purposes.
- `deleteListener(target: document | element)` delete the listener for the given DOM node
- `clear()` remove all listeners

The hook takes three arguments:

- `type` the DOM event to listen to
- `options` an optional object allowing for additional properties to be defined on the event listener. The options are:
  - `passive` provide an optional flag that tells the listener to register a passive DOM event listener or an active DOM event listener
  - `capture` provide an optional flag that tells thge listener callback to fire in the capture phase or the bubble phase
  - `priority` provide an optional Scheduler priority that allows React to correct schedule the listener callback to fire at the correct priority.

## Note

For propagation, the same rules of `stopPropgation` and `stopImmediatePropgation` apply to these event listeners. These methods are actually monkey-patched, as we use the actual native DOM evnets with this system and API, rather than Synthetic Events. `currentTarget` and `eventPhase` are also respectfully monkey-patched to co-ordinate and align with the propagation system involved internally within React.

Furthermore, all event listeners are passive by default. If is desired to called `event.preventDefault` on an event listener, then the event listener should be made active via the `passive` option.

## Examples

An example of a basic clickable button:

```jsx
import {useRef, useEffect} from 'react';
import {useEvent} from 'react-dom';

function Button({children, onClick}) {
  const buttonRef = useRef(null);
  const clickEvent = useEvent('click');

  useEffect(() => {
    clickEvent.setListener(buttonRef.current, onClick);
  });

  return <button ref={buttonRef}>{children}</button>;
}
```

If you want to listen to events that are delegated to the document, you can do that:

```jsx
import {useRef, useEffect} from 'react';
import {useEvent} from 'react-dom';

function Button({children, onClick}) {
  const clickEvent = useEvent('click');

  useEffect(() => {
    // Pass in `document`, which is supported with this API
    // Note: `window` is not supported, as React doesn't
    // listen to events that high up.
    clickEvent.setListener(document, onClick);
  });

  return <button>{children}</button>;
}
```

If you wanted to extract the verbosity out of this into a custom hook, then it's possible to do so:

```jsx
import {useRef, useEffect} from 'react';
import {useEvent} from 'react-dom';

function useClick(onClick) {
  const buttonRef = useRef(null);
  const clickEvent = useEvent('click');

  useEffect(() => {
    clickEvent.setListener(buttonRef.current, onClick);
  });

  return buttonRef;
}

function Button({children}) {
  const buttonRef = useClick(() => {
    console.log('Hello world!')
  });
  return <button ref={buttonRef}>{children}</button>;
}
```

A more complex button that tracks when the button is being pressed with the mouse:

```jsx
import {useRef, useEffect} from 'react';
import {useEvent} from 'react-dom';

function Button({children, onClick}) {
  const buttonRef = useRef(null);
  const [pressed, setPressed] = useState(false);
  const click = useEvent('click');
  const mouseUp = useEvent('mouseup');
  const mouseDown = useEvent('mousedown');

  useEffect(() => {
    const button = buttonRef.current;

    const handleMouseUp = () => {
      setPressed(false);
    };
    const handleMouseDown = () => {
      setPressed(true); 
    };

    clickEvent.setListener(button, onClick);
    if (pressed) {
      mouseUp.setListener(button, handleMouseDown);
    } else {
      mouseDown.setListener(button, handleMouseDown);
    }

    return () => {
      mouseDown.deleteListener(button);
      mouseUp.deleteListener(button);
    };
  }, [pressed]);

  return (
    <button ref={buttonRef} className={pressed && 'pressed'}>
      {children}
    </button>
  );
}
```

## Work in progress

This PR is still a work-in-progress, and priorities relating to how flushing and controlled components still needs to be worked out. I also intend to add far more tests and ensure that some of the React Flare responders we created in the past, can be modelled on top of this API and redesign.
