### PR TITLE
Mirror of facebook react#17678

### DIFF
--- a/packages/react-dom/src/events/DOMEventPriority.js
+++ b/packages/react-dom/src/events/DOMEventPriority.js
@@ -1,0 +1,125 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type {EventPriority} from 'shared/ReactTypes';
+import type {TopLevelType} from 'legacy-events/TopLevelEventTypes';
+
+import * as DOMTopLevelEventTypes from './DOMTopLevelEventTypes';
+import {
+  DiscreteEvent,
+  UserBlockingEvent,
+  ContinuousEvent,
+} from 'shared/ReactTypes';
+
+// We use multiple Sets to improve code size
+// vs using an object for a map. Furthermore,
+// in benchmarking the various approaches,
+// doing lookups with Sets turned out faster
+// than using the previous object lookup, which
+// was dynamically generated (thus maybe somewhat
+// slower that for V8 optimizations).
+const discreteEvents = new Set([
+  DOMTopLevelEventTypes.TOP_BLUR,
+  DOMTopLevelEventTypes.TOP_CANCEL,
+  DOMTopLevelEventTypes.TOP_CLICK,
+  DOMTopLevelEventTypes.TOP_CLOSE,
+  DOMTopLevelEventTypes.TOP_CONTEXT_MENU,
+  DOMTopLevelEventTypes.TOP_COPY,
+  DOMTopLevelEventTypes.TOP_CUT,
+  DOMTopLevelEventTypes.TOP_AUX_CLICK,
+  DOMTopLevelEventTypes.TOP_DOUBLE_CLICK,
+  DOMTopLevelEventTypes.TOP_DRAG_END,
+  DOMTopLevelEventTypes.TOP_DRAG_START,
+  DOMTopLevelEventTypes.TOP_DROP,
+  DOMTopLevelEventTypes.TOP_FOCUS,
+  DOMTopLevelEventTypes.TOP_INPUT,
+  DOMTopLevelEventTypes.TOP_INVALID,
+  DOMTopLevelEventTypes.TOP_KEY_DOWN,
+  DOMTopLevelEventTypes.TOP_KEY_PRESS,
+  DOMTopLevelEventTypes.TOP_KEY_UP,
+  DOMTopLevelEventTypes.TOP_MOUSE_DOWN,
+  DOMTopLevelEventTypes.TOP_MOUSE_UP,
+  DOMTopLevelEventTypes.TOP_PASTE,
+  DOMTopLevelEventTypes.TOP_PAUSE,
+  DOMTopLevelEventTypes.TOP_PLAY,
+  DOMTopLevelEventTypes.TOP_POINTER_CANCEL,
+  DOMTopLevelEventTypes.TOP_POINTER_DOWN,
+  DOMTopLevelEventTypes.TOP_POINTER_UP,
+  DOMTopLevelEventTypes.TOP_RATE_CHANGE,
+  DOMTopLevelEventTypes.TOP_RESET,
+  DOMTopLevelEventTypes.TOP_SEEKED,
+  DOMTopLevelEventTypes.TOP_SUBMIT,
+  DOMTopLevelEventTypes.TOP_TOUCH_CANCEL,
+  DOMTopLevelEventTypes.TOP_TOUCH_END,
+  DOMTopLevelEventTypes.TOP_TOUCH_START,
+  DOMTopLevelEventTypes.TOP_VOLUME_CHANGE,
+]);
+
+const userBlockingEvents = new Set([
+  DOMTopLevelEventTypes.TOP_DRAG,
+  DOMTopLevelEventTypes.TOP_DRAG_ENTER,
+  DOMTopLevelEventTypes.TOP_DRAG_EXIT,
+  DOMTopLevelEventTypes.TOP_DRAG_LEAVE,
+  DOMTopLevelEventTypes.TOP_DRAG_OVER,
+  DOMTopLevelEventTypes.TOP_MOUSE_MOVE,
+  DOMTopLevelEventTypes.TOP_MOUSE_OUT,
+  DOMTopLevelEventTypes.TOP_MOUSE_OVER,
+  DOMTopLevelEventTypes.TOP_POINTER_MOVE,
+  DOMTopLevelEventTypes.TOP_POINTER_OUT,
+  DOMTopLevelEventTypes.TOP_POINTER_OVER,
+  DOMTopLevelEventTypes.TOP_SCROLL,
+  DOMTopLevelEventTypes.TOP_TOGGLE,
+  DOMTopLevelEventTypes.TOP_TOUCH_MOVE,
+  DOMTopLevelEventTypes.TOP_WHEEL,
+]);
+
+// To be used by the Listener API
+// const continuousEvents = new Set([
+//   DOMTopLevelEventTypes.TOP_ABORT,
+//   DOMTopLevelEventTypes.TOP_ANIMATION_END,
+//   DOMTopLevelEventTypes.TOP_ANIMATION_ITERATION,
+//   DOMTopLevelEventTypes.TOP_ANIMATION_START,
+//   DOMTopLevelEventTypes.TOP_CAN_PLAY,
+//   DOMTopLevelEventTypes.TOP_CAN_PLAY_THROUGH,
+//   DOMTopLevelEventTypes.TOP_DURATION_CHANGE,
+//   DOMTopLevelEventTypes.TOP_EMPTIED,
+//   DOMTopLevelEventTypes.TOP_ENCRYPTED,
+//   DOMTopLevelEventTypes.TOP_ENDED,
+//   DOMTopLevelEventTypes.TOP_ERROR,
+//   DOMTopLevelEventTypes.TOP_GOT_POINTER_CAPTURE,
+//   DOMTopLevelEventTypes.TOP_LOAD,
+//   DOMTopLevelEventTypes.TOP_LOADED_DATA,
+//   DOMTopLevelEventTypes.TOP_LOADED_METADATA,
+//   DOMTopLevelEventTypes.TOP_LOAD_START,
+//   DOMTopLevelEventTypes.TOP_LOST_POINTER_CAPTURE,
+//   DOMTopLevelEventTypes.TOP_PLAYING,
+//   DOMTopLevelEventTypes.TOP_PROGRESS,
+//   DOMTopLevelEventTypes.TOP_SEEKING,
+//   DOMTopLevelEventTypes.TOP_STALLED,
+//   DOMTopLevelEventTypes.TOP_SUSPEND,
+//   DOMTopLevelEventTypes.TOP_TIME_UPDATE,
+//   DOMTopLevelEventTypes.TOP_TRANSITION_END,
+//   DOMTopLevelEventTypes.TOP_WAITING,
+// ]);
+
+export function getEventPriorityForPluginSystem(
+  topLevelType: TopLevelType,
+): EventPriority {
+  if (discreteEvents.has(topLevelType)) {
+    return DiscreteEvent;
+  }
+  if (userBlockingEvents.has(topLevelType)) {
+    return UserBlockingEvent;
+  }
+  // If it is not either of the above, then we
+  // default to a ContinuousEvent. Note: we might
+  // want to warn if we can't detect the priority
+  // for the event.
+  return ContinuousEvent;
+}

--- a/packages/react-dom/src/events/ReactDOMEventListener.js
+++ b/packages/react-dom/src/events/ReactDOMEventListener.js
@@ -59,7 +59,6 @@ import {
 } from './EventListener';
 import getEventTarget from './getEventTarget';
 import {getClosestInstanceFromNode} from '../client/ReactDOMComponentTree';
-import SimpleEventPlugin from './SimpleEventPlugin';
 import {getRawEventName} from './DOMTopLevelEventTypes';
 import {passiveBrowserEventsSupported} from './checkPassiveEvents';
 
@@ -69,13 +68,12 @@ import {
   ContinuousEvent,
   DiscreteEvent,
 } from 'shared/ReactTypes';
+import {getEventPriorityForPluginSystem} from './DOMEventPriority';
 
 const {
   unstable_UserBlockingPriority: UserBlockingPriority,
   unstable_runWithPriority: runWithPriority,
 } = Scheduler;
-
-const {getEventPriority} = SimpleEventPlugin;
 
 const CALLBACK_BOOKKEEPING_POOL_SIZE = 10;
 const callbackBookkeepingPool = [];
@@ -280,7 +278,7 @@ function trapEventForPluginEventSystem(
   capture: boolean,
 ): void {
   let listener;
-  switch (getEventPriority(topLevelType)) {
+  switch (getEventPriorityForPluginSystem(topLevelType)) {
     case DiscreteEvent:
       listener = dispatchDiscreteEvent.bind(
         null,

--- a/packages/react-dom/src/events/SimpleEventPlugin.js
+++ b/packages/react-dom/src/events/SimpleEventPlugin.js
@@ -7,7 +7,6 @@
  * @flow
  */
 
-import type {EventPriority} from 'shared/ReactTypes';
 import type {
   TopLevelType,
   DOMTopLevelEventType,
@@ -20,11 +19,6 @@ import type {Fiber} from 'react-reconciler/src/ReactFiber';
 import type {EventTypes, PluginModule} from 'legacy-events/PluginModuleType';
 import type {EventSystemFlags} from 'legacy-events/EventSystemFlags';
 
-import {
-  DiscreteEvent,
-  UserBlockingEvent,
-  ContinuousEvent,
-} from 'shared/ReactTypes';
 import {accumulateTwoPhaseDispatches} from 'legacy-events/EventPropagators';
 import SyntheticEvent from 'legacy-events/SyntheticEvent';
 
@@ -42,6 +36,7 @@ import SyntheticTransitionEvent from './SyntheticTransitionEvent';
 import SyntheticUIEvent from './SyntheticUIEvent';
 import SyntheticWheelEvent from './SyntheticWheelEvent';
 import getEventCharCode from './getEventCharCode';
+import {getEventPriorityForPluginSystem} from './DOMEventPriority';
 
 /**
  * Turns
@@ -62,116 +57,83 @@ import getEventCharCode from './getEventCharCode';
  * ]);
  */
 
-type EventTuple = [DOMTopLevelEventType, string, EventPriority];
+type EventTuple = [DOMTopLevelEventType, string];
 
 const eventTuples: Array<EventTuple> = [
-  // Discrete events
-  [DOMTopLevelEventTypes.TOP_BLUR, 'blur', DiscreteEvent],
-  [DOMTopLevelEventTypes.TOP_CANCEL, 'cancel', DiscreteEvent],
-  [DOMTopLevelEventTypes.TOP_CLICK, 'click', DiscreteEvent],
-  [DOMTopLevelEventTypes.TOP_CLOSE, 'close', DiscreteEvent],
-  [DOMTopLevelEventTypes.TOP_CONTEXT_MENU, 'contextMenu', DiscreteEvent],
-  [DOMTopLevelEventTypes.TOP_COPY, 'copy', DiscreteEvent],
-  [DOMTopLevelEventTypes.TOP_CUT, 'cut', DiscreteEvent],
-  [DOMTopLevelEventTypes.TOP_AUX_CLICK, 'auxClick', DiscreteEvent],
-  [DOMTopLevelEventTypes.TOP_DOUBLE_CLICK, 'doubleClick', DiscreteEvent],
-  [DOMTopLevelEventTypes.TOP_DRAG_END, 'dragEnd', DiscreteEvent],
-  [DOMTopLevelEventTypes.TOP_DRAG_START, 'dragStart', DiscreteEvent],
-  [DOMTopLevelEventTypes.TOP_DROP, 'drop', DiscreteEvent],
-  [DOMTopLevelEventTypes.TOP_FOCUS, 'focus', DiscreteEvent],
-  [DOMTopLevelEventTypes.TOP_INPUT, 'input', DiscreteEvent],
-  [DOMTopLevelEventTypes.TOP_INVALID, 'invalid', DiscreteEvent],
-  [DOMTopLevelEventTypes.TOP_KEY_DOWN, 'keyDown', DiscreteEvent],
-  [DOMTopLevelEventTypes.TOP_KEY_PRESS, 'keyPress', DiscreteEvent],
-  [DOMTopLevelEventTypes.TOP_KEY_UP, 'keyUp', DiscreteEvent],
-  [DOMTopLevelEventTypes.TOP_MOUSE_DOWN, 'mouseDown', DiscreteEvent],
-  [DOMTopLevelEventTypes.TOP_MOUSE_UP, 'mouseUp', DiscreteEvent],
-  [DOMTopLevelEventTypes.TOP_PASTE, 'paste', DiscreteEvent],
-  [DOMTopLevelEventTypes.TOP_PAUSE, 'pause', DiscreteEvent],
-  [DOMTopLevelEventTypes.TOP_PLAY, 'play', DiscreteEvent],
-  [DOMTopLevelEventTypes.TOP_POINTER_CANCEL, 'pointerCancel', DiscreteEvent],
-  [DOMTopLevelEventTypes.TOP_POINTER_DOWN, 'pointerDown', DiscreteEvent],
-  [DOMTopLevelEventTypes.TOP_POINTER_UP, 'pointerUp', DiscreteEvent],
-  [DOMTopLevelEventTypes.TOP_RATE_CHANGE, 'rateChange', DiscreteEvent],
-  [DOMTopLevelEventTypes.TOP_RESET, 'reset', DiscreteEvent],
-  [DOMTopLevelEventTypes.TOP_SEEKED, 'seeked', DiscreteEvent],
-  [DOMTopLevelEventTypes.TOP_SUBMIT, 'submit', DiscreteEvent],
-  [DOMTopLevelEventTypes.TOP_TOUCH_CANCEL, 'touchCancel', DiscreteEvent],
-  [DOMTopLevelEventTypes.TOP_TOUCH_END, 'touchEnd', DiscreteEvent],
-  [DOMTopLevelEventTypes.TOP_TOUCH_START, 'touchStart', DiscreteEvent],
-  [DOMTopLevelEventTypes.TOP_VOLUME_CHANGE, 'volumeChange', DiscreteEvent],
-
-  // User-blocking events
-  [DOMTopLevelEventTypes.TOP_DRAG, 'drag', UserBlockingEvent],
-  [DOMTopLevelEventTypes.TOP_DRAG_ENTER, 'dragEnter', UserBlockingEvent],
-  [DOMTopLevelEventTypes.TOP_DRAG_EXIT, 'dragExit', UserBlockingEvent],
-  [DOMTopLevelEventTypes.TOP_DRAG_LEAVE, 'dragLeave', UserBlockingEvent],
-  [DOMTopLevelEventTypes.TOP_DRAG_OVER, 'dragOver', UserBlockingEvent],
-  [DOMTopLevelEventTypes.TOP_MOUSE_MOVE, 'mouseMove', UserBlockingEvent],
-  [DOMTopLevelEventTypes.TOP_MOUSE_OUT, 'mouseOut', UserBlockingEvent],
-  [DOMTopLevelEventTypes.TOP_MOUSE_OVER, 'mouseOver', UserBlockingEvent],
-  [DOMTopLevelEventTypes.TOP_POINTER_MOVE, 'pointerMove', UserBlockingEvent],
-  [DOMTopLevelEventTypes.TOP_POINTER_OUT, 'pointerOut', UserBlockingEvent],
-  [DOMTopLevelEventTypes.TOP_POINTER_OVER, 'pointerOver', UserBlockingEvent],
-  [DOMTopLevelEventTypes.TOP_SCROLL, 'scroll', UserBlockingEvent],
-  [DOMTopLevelEventTypes.TOP_TOGGLE, 'toggle', UserBlockingEvent],
-  [DOMTopLevelEventTypes.TOP_TOUCH_MOVE, 'touchMove', UserBlockingEvent],
-  [DOMTopLevelEventTypes.TOP_WHEEL, 'wheel', UserBlockingEvent],
-
-  // Continuous events
-  [DOMTopLevelEventTypes.TOP_ABORT, 'abort', ContinuousEvent],
-  [DOMTopLevelEventTypes.TOP_ANIMATION_END, 'animationEnd', ContinuousEvent],
-  [
-    DOMTopLevelEventTypes.TOP_ANIMATION_ITERATION,
-    'animationIteration',
-    ContinuousEvent,
-  ],
-  [
-    DOMTopLevelEventTypes.TOP_ANIMATION_START,
-    'animationStart',
-    ContinuousEvent,
-  ],
-  [DOMTopLevelEventTypes.TOP_CAN_PLAY, 'canPlay', ContinuousEvent],
-  [
-    DOMTopLevelEventTypes.TOP_CAN_PLAY_THROUGH,
-    'canPlayThrough',
-    ContinuousEvent,
-  ],
-  [
-    DOMTopLevelEventTypes.TOP_DURATION_CHANGE,
-    'durationChange',
-    ContinuousEvent,
-  ],
-  [DOMTopLevelEventTypes.TOP_EMPTIED, 'emptied', ContinuousEvent],
-  [DOMTopLevelEventTypes.TOP_ENCRYPTED, 'encrypted', ContinuousEvent],
-  [DOMTopLevelEventTypes.TOP_ENDED, 'ended', ContinuousEvent],
-  [DOMTopLevelEventTypes.TOP_ERROR, 'error', ContinuousEvent],
-  [
-    DOMTopLevelEventTypes.TOP_GOT_POINTER_CAPTURE,
-    'gotPointerCapture',
-    ContinuousEvent,
-  ],
-  [DOMTopLevelEventTypes.TOP_LOAD, 'load', ContinuousEvent],
-  [DOMTopLevelEventTypes.TOP_LOADED_DATA, 'loadedData', ContinuousEvent],
-  [
-    DOMTopLevelEventTypes.TOP_LOADED_METADATA,
-    'loadedMetadata',
-    ContinuousEvent,
-  ],
-  [DOMTopLevelEventTypes.TOP_LOAD_START, 'loadStart', ContinuousEvent],
-  [
-    DOMTopLevelEventTypes.TOP_LOST_POINTER_CAPTURE,
-    'lostPointerCapture',
-    ContinuousEvent,
-  ],
-  [DOMTopLevelEventTypes.TOP_PLAYING, 'playing', ContinuousEvent],
-  [DOMTopLevelEventTypes.TOP_PROGRESS, 'progress', ContinuousEvent],
-  [DOMTopLevelEventTypes.TOP_SEEKING, 'seeking', ContinuousEvent],
-  [DOMTopLevelEventTypes.TOP_STALLED, 'stalled', ContinuousEvent],
-  [DOMTopLevelEventTypes.TOP_SUSPEND, 'suspend', ContinuousEvent],
-  [DOMTopLevelEventTypes.TOP_TIME_UPDATE, 'timeUpdate', ContinuousEvent],
-  [DOMTopLevelEventTypes.TOP_TRANSITION_END, 'transitionEnd', ContinuousEvent],
-  [DOMTopLevelEventTypes.TOP_WAITING, 'waiting', ContinuousEvent],
+  [DOMTopLevelEventTypes.TOP_BLUR, 'blur'],
+  [DOMTopLevelEventTypes.TOP_CANCEL, 'cancel'],
+  [DOMTopLevelEventTypes.TOP_CLICK, 'click'],
+  [DOMTopLevelEventTypes.TOP_CLOSE, 'close'],
+  [DOMTopLevelEventTypes.TOP_CONTEXT_MENU, 'contextMenu'],
+  [DOMTopLevelEventTypes.TOP_COPY, 'copy'],
+  [DOMTopLevelEventTypes.TOP_CUT, 'cut'],
+  [DOMTopLevelEventTypes.TOP_AUX_CLICK, 'auxClick'],
+  [DOMTopLevelEventTypes.TOP_DOUBLE_CLICK, 'doubleClick'],
+  [DOMTopLevelEventTypes.TOP_DRAG_END, 'dragEnd'],
+  [DOMTopLevelEventTypes.TOP_DRAG_START, 'dragStart'],
+  [DOMTopLevelEventTypes.TOP_DROP, 'drop'],
+  [DOMTopLevelEventTypes.TOP_FOCUS, 'focus'],
+  [DOMTopLevelEventTypes.TOP_INPUT, 'input'],
+  [DOMTopLevelEventTypes.TOP_INVALID, 'invalid'],
+  [DOMTopLevelEventTypes.TOP_KEY_DOWN, 'keyDown'],
+  [DOMTopLevelEventTypes.TOP_KEY_PRESS, 'keyPress'],
+  [DOMTopLevelEventTypes.TOP_KEY_UP, 'keyUp'],
+  [DOMTopLevelEventTypes.TOP_MOUSE_DOWN, 'mouseDown'],
+  [DOMTopLevelEventTypes.TOP_MOUSE_UP, 'mouseUp'],
+  [DOMTopLevelEventTypes.TOP_PASTE, 'paste'],
+  [DOMTopLevelEventTypes.TOP_PAUSE, 'pause'],
+  [DOMTopLevelEventTypes.TOP_PLAY, 'play'],
+  [DOMTopLevelEventTypes.TOP_POINTER_CANCEL, 'pointerCancel'],
+  [DOMTopLevelEventTypes.TOP_POINTER_DOWN, 'pointerDown'],
+  [DOMTopLevelEventTypes.TOP_POINTER_UP, 'pointerUp'],
+  [DOMTopLevelEventTypes.TOP_RATE_CHANGE, 'rateChange'],
+  [DOMTopLevelEventTypes.TOP_RESET, 'reset'],
+  [DOMTopLevelEventTypes.TOP_SEEKED, 'seeked'],
+  [DOMTopLevelEventTypes.TOP_SUBMIT, 'submit'],
+  [DOMTopLevelEventTypes.TOP_TOUCH_CANCEL, 'touchCancel'],
+  [DOMTopLevelEventTypes.TOP_TOUCH_END, 'touchEnd'],
+  [DOMTopLevelEventTypes.TOP_TOUCH_START, 'touchStart'],
+  [DOMTopLevelEventTypes.TOP_VOLUME_CHANGE, 'volumeChange'],
+  [DOMTopLevelEventTypes.TOP_DRAG, 'drag'],
+  [DOMTopLevelEventTypes.TOP_DRAG_ENTER, 'dragEnter'],
+  [DOMTopLevelEventTypes.TOP_DRAG_EXIT, 'dragExit'],
+  [DOMTopLevelEventTypes.TOP_DRAG_LEAVE, 'dragLeave'],
+  [DOMTopLevelEventTypes.TOP_DRAG_OVER, 'dragOver'],
+  [DOMTopLevelEventTypes.TOP_MOUSE_MOVE, 'mouseMove'],
+  [DOMTopLevelEventTypes.TOP_MOUSE_OUT, 'mouseOut'],
+  [DOMTopLevelEventTypes.TOP_MOUSE_OVER, 'mouseOver'],
+  [DOMTopLevelEventTypes.TOP_POINTER_MOVE, 'pointerMove'],
+  [DOMTopLevelEventTypes.TOP_POINTER_OUT, 'pointerOut'],
+  [DOMTopLevelEventTypes.TOP_POINTER_OVER, 'pointerOver'],
+  [DOMTopLevelEventTypes.TOP_SCROLL, 'scroll'],
+  [DOMTopLevelEventTypes.TOP_TOGGLE, 'toggle'],
+  [DOMTopLevelEventTypes.TOP_TOUCH_MOVE, 'touchMove'],
+  [DOMTopLevelEventTypes.TOP_WHEEL, 'wheel'],
+  [DOMTopLevelEventTypes.TOP_ABORT, 'abort'],
+  [DOMTopLevelEventTypes.TOP_ANIMATION_END, 'animationEnd'],
+  [DOMTopLevelEventTypes.TOP_ANIMATION_ITERATION, 'animationIteration'],
+  [DOMTopLevelEventTypes.TOP_ANIMATION_START, 'animationStart'],
+  [DOMTopLevelEventTypes.TOP_CAN_PLAY, 'canPlay'],
+  [DOMTopLevelEventTypes.TOP_CAN_PLAY_THROUGH, 'canPlayThrough'],
+  [DOMTopLevelEventTypes.TOP_DURATION_CHANGE, 'durationChange'],
+  [DOMTopLevelEventTypes.TOP_EMPTIED, 'emptied'],
+  [DOMTopLevelEventTypes.TOP_ENCRYPTED, 'encrypted'],
+  [DOMTopLevelEventTypes.TOP_ENDED, 'ended'],
+  [DOMTopLevelEventTypes.TOP_ERROR, 'error'],
+  [DOMTopLevelEventTypes.TOP_GOT_POINTER_CAPTURE, 'gotPointerCapture'],
+  [DOMTopLevelEventTypes.TOP_LOAD, 'load'],
+  [DOMTopLevelEventTypes.TOP_LOADED_DATA, 'loadedData'],
+  [DOMTopLevelEventTypes.TOP_LOADED_METADATA, 'loadedMetadata'],
+  [DOMTopLevelEventTypes.TOP_LOAD_START, 'loadStart'],
+  [DOMTopLevelEventTypes.TOP_LOST_POINTER_CAPTURE, 'lostPointerCapture'],
+  [DOMTopLevelEventTypes.TOP_PLAYING, 'playing'],
+  [DOMTopLevelEventTypes.TOP_PROGRESS, 'progress'],
+  [DOMTopLevelEventTypes.TOP_SEEKING, 'seeking'],
+  [DOMTopLevelEventTypes.TOP_STALLED, 'stalled'],
+  [DOMTopLevelEventTypes.TOP_SUSPEND, 'suspend'],
+  [DOMTopLevelEventTypes.TOP_TIME_UPDATE, 'timeUpdate'],
+  [DOMTopLevelEventTypes.TOP_TRANSITION_END, 'transitionEnd'],
+  [DOMTopLevelEventTypes.TOP_WAITING, 'waiting'],
 ];
 
 const eventTypes: EventTypes = {};
@@ -183,7 +145,7 @@ for (let i = 0; i < eventTuples.length; i++) {
   const eventTuple = eventTuples[i];
   const topEvent = eventTuple[0];
   const event = eventTuple[1];
-  const eventPriority = eventTuple[2];
+  const eventPriority = getEventPriorityForPluginSystem(topEvent);
 
   const capitalizedEvent = event[0].toUpperCase() + event.slice(1);
   const onEvent = 'on' + capitalizedEvent;
@@ -235,15 +197,8 @@ const knownHTMLTopLevelTypes: Array<DOMTopLevelEventType> = [
   DOMTopLevelEventTypes.TOP_WAITING,
 ];
 
-const SimpleEventPlugin: PluginModule<MouseEvent> & {
-  getEventPriority: (topLevelType: TopLevelType) => EventPriority,
-} = {
+const SimpleEventPlugin: PluginModule<MouseEvent> = {
   eventTypes: eventTypes,
-
-  getEventPriority(topLevelType: TopLevelType): EventPriority {
-    const config = topLevelEventsToDispatchConfig[topLevelType];
-    return config !== undefined ? config.eventPriority : ContinuousEvent;
-  },
 
   extractEvents: function(
     topLevelType: TopLevelType,


### PR DESCRIPTION
Mirror of facebook react#17678
The team have mentioned a bunch of times that it felt wrong that DOM Event Priority handling was all coupled with the SimpleEventPlugin, especially as might want to extend on the priorities with newer features and refactors in the future.

This PR breaks out the priority logic into a dedicated module and makes uses of Sets for faster lookups (I benchmarked before and after and Sets were consistently faster than object property lookups). The size difference should be neglible at best as all these strings should gzip nicely, but mostly it makes the logic easier to follow now, which is likely a better trade-off given we want to address codesize more aggressively in the future.

```
1 run
event object: 0.09ms
event sets: 0.08ms

100 runs
event object: 0.21ms
event sets: 0.19ms

1k runs
event object: 1.3ms
event sets: 1.1ms

10k runs
event object: 4.1ms
event sets: 3.7ms
```
